### PR TITLE
Relax rubicure version

### DIFF
--- a/cureutils.gemspec
+++ b/cureutils.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_dependency 'thor', ['>= 0.19.1', '< 2']
-  spec.add_dependency 'rubicure', '~> 0.4.4'
+  spec.add_dependency 'rubicure', '~> 0.4'
   spec.add_dependency 'colorize', '~> 0.7.7'
   spec.add_dependency 'activesupport', '~> 4.2.6'
 end


### PR DESCRIPTION
`'~> 0.4.4'` だと v0.4.4以上、v0.5.0未満のバージョン指定になります。

ref. [Patterns - RubyGems Guides](http://guides.rubygems.org/patterns/)

v0.4系のうちはいいですがv0.5系（おそらく次回作）が出た時に最新版のrubicureが入らなくなってしまうのでバージョン指定を緩めました。

本当はバージョン指定自体削ってもよさそうでしたが、0系から1系にする時に破壊的な変更しないとも限らないので `'~> 0.4'`（v0.4以上v1.0未満）にしています。