### PR TITLE
Feature/refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+/tags

--- a/bin/cure
+++ b/bin/cure
@@ -1,4 +1,13 @@
 #!/usr/bin/env ruby
-require "cureutils"
 
-Cureutils::CLI.start
+# Trap intrrupts to quit cleanly.
+# Refer to https://twitter.com/mitchellh/status/283014103189053442
+Signal.trap('INT') { abort }
+
+require 'cureutils'
+
+begin
+  Cureutils::CLI.start
+rescue Interrupt
+  abort('Interrupted...')
+end

--- a/etc/cure-completion.zsh
+++ b/etc/cure-completion.zsh
@@ -4,6 +4,7 @@
 
 # cure CMD
 subcommands=(
+	"version: Output the version number."
 	"help: Output the usage and exit."
 	"date: Display date, time and Precure related events."
 	"echo: Print messages of Precure."
@@ -18,48 +19,49 @@ subcommands=(
 
 # cure precures | cure tr [:precure_name:] [:girl_name:] | grep '[[:alnum:]]' | sort | uniq | sed 's/^cure_//'
 precure_girl_names=(
-	'ace'
-	'aqua'
-	'beat'
-	'beauty'
-	'berry'
-	'black'
-	'bloom'
-	'blossom'
-	'diamond'
-	'dream'
-	'echo'
-	'egret'
-	'flora'
-	'fortune'
-	'happy'
-	'heart'
-	'honey'
-	'lemonade'
-	'lovely'
-	'magical'
-	'march'
-	'marine'
-	'melody'
-	'mermaid'
-	'mint'
-	'miracle'
-	'moonlight'
-	'muse'
-	'passion'
-	'peace'
-	'peach'
-	'pine'
-	'princess'
-	'rhythm'
-	'rosetta'
-	'rouge'
-	'scarlet'
-	'sunny'
-	'sunshine'
-	'sword'
-	'twinkle'
-	'white'
+	'cure_ace'
+	'cure_aqua'
+	'cure_beat'
+	'cure_beauty'
+	'cure_berry'
+	'cure_black'
+	'cure_bloom'
+	'cure_blossom'
+	'cure_diamond'
+	'cure_dream'
+	'cure_echo'
+	'cure_egret'
+	'cure_felice'
+	'cure_flora'
+	'cure_fortune'
+	'cure_happy'
+	'cure_heart'
+	'cure_honey'
+	'cure_lemonade'
+	'cure_lovely'
+	'cure_magical'
+	'cure_march'
+	'cure_marine'
+	'cure_melody'
+	'cure_mermaid'
+	'cure_mint'
+	'cure_miracle'
+	'cure_moonlight'
+	'cure_muse'
+	'cure_passion'
+	'cure_peace'
+	'cure_peach'
+	'cure_pine'
+	'cure_princess'
+	'cure_rhythm'
+	'cure_rosetta'
+	'cure_rouge'
+	'cure_scarlet'
+	'cure_sunny'
+	'cure_sunshine'
+	'cure_sword'
+	'cure_twinkle'
+	'cure_white'
 	'milky_rose'
 	'shiny_luminous'
 )
@@ -110,6 +112,23 @@ function _cure-date () {
 	fi
 	if (( CURRENT==5 )) ; then
 		shift args
+		_describe -t args 'args' args
+	fi
+}
+
+function _cure-precures () {
+	local -a args
+	if (( CURRENT>=3 )) ; then
+		echo $words | grep -w -- '-m' 1> /dev/null || args=($args '-m:Include who have only appeared in the movies.')
+		_describe -t args 'args' args
+	fi
+}
+
+function _cure-girls () {
+	local -a args
+	if (( CURRENT>=3 )) ; then
+		echo $words | grep -w -- '-v' 1> /dev/null || args=($args "-v:Include particular girl's full name.")
+		echo $words | grep -w -- '-m' 1> /dev/null || args=($args '-m:Include who have only appeared in the movies.')
 		_describe -t args 'args' args
 	fi
 }

--- a/lib/cureutils/cli.rb
+++ b/lib/cureutils/cli.rb
@@ -41,15 +41,36 @@ module Cureutils
     end
 
     desc 'girls', "Print girls' name"
+    option 'verbose',   aliases: 'v',
+                        type: :boolean,
+                        desc: "Include particular girl's full name."
+    option 'movie',     aliases: 'm',
+                        type: :boolean,
+                        desc: 'Include who have only appeared in the movies.'
     def girls
-      Rubicure::Girl.config.map { |_k, v| v[:human_name] }.uniq.each do |v|
-        puts v
+      girls = Precure.all_stars
+      girls = girls << Cure.echo if options[:movie]
+      girls.map!(&:human_name)
+      if options[:verbose]
+        girls.each do |v|
+          puts v
+        end
+      else
+        girls.each do |v|
+          puts v.gsub(/\([^\)]+\)$/, '')
+        end
       end
     end
 
     desc 'precures', 'Print Precure names'
+    option 'movie',     aliases: 'm',
+                        type: :boolean,
+                        desc: 'Include who have only appeared in the movies.'
     def precures
-      Rubicure::Girl.config.map { |_k, v| v[:precure_name] }.uniq.each do |v|
+      cures = Precure.all_stars
+      cures = cures << Cure.echo if options[:movie]
+      cures.map!(&:precure_name)
+      cures.each do |v|
         puts v
       end
     end

--- a/lib/cureutils/cli.rb
+++ b/lib/cureutils/cli.rb
@@ -24,7 +24,12 @@ module Cureutils
       end
     end
 
-    desc 'transform', 'Change human_name to precure_name'
+    desc 'version', 'Output the version number.'
+    def version
+      puts "#{Cureutils.name} #{Cureutils::Version}"
+    end
+
+    desc 'transform', 'Change human_name to precure_name.'
     def transform
       manager = CureTranslateManager.new
       manager.translate_from_to('[:human_name:]', '[:precure_name:]')
@@ -40,7 +45,7 @@ module Cureutils
       exit(manager.print_results)
     end
 
-    desc 'girls', "Print girls' name"
+    desc 'girls [OPTIONS]', "Print girls' name."
     option 'verbose',   aliases: 'v',
                         type: :boolean,
                         desc: "Include particular girl's full name."
@@ -62,7 +67,7 @@ module Cureutils
       end
     end
 
-    desc 'precures', 'Print Precure names'
+    desc 'precures [OPTIONS]', 'Print Precure names.'
     option 'movie',     aliases: 'm',
                         type: :boolean,
                         desc: 'Include who have only appeared in the movies.'

--- a/lib/cureutils/version.rb
+++ b/lib/cureutils/version.rb
@@ -1,8 +1,8 @@
 module Cureutils
   class Version
     MAJOR = 0
-    MINOR = 1
-    PATCH = 5
+    MINOR = 2
+    PATCH = 0
     PRE = nil
 
     class << self

--- a/test/test.sh
+++ b/test/test.sh
@@ -10,6 +10,12 @@ tearDown(){
   [ -e tmpfile ] && rm tmpfile
 }
 
+test_version(){
+    result=`bundle exec cure version`
+    echo "${result}" | grep -E '^Cureutils [\.0-9]+$'
+    assertEquals 0 $?
+}
+
 test_girls(){
     result=`bundle exec cure girls`
     echo "${result}" | grep "美墨なぎさ"
@@ -100,8 +106,8 @@ test_girls(){
     assertEquals 0 $?
     echo "${result}" | grep "花海ことは"
     assertEquals 0 $?
-    echo "${result}" | grep "坂上あゆみ"
-    assertEquals 0 $?
+    # echo "${result}" | grep "坂上あゆみ"
+    # assertEquals 0 $?
 }
 
 test_precures () {
@@ -116,10 +122,10 @@ test_precures () {
     assertEquals 0 $?
     echo "${result}" | grep "キュアイーグレット"
     assertEquals 0 $?
-    echo "${result}" | grep "キュアブライト"
-    assertEquals 0 $?
-    echo "${result}" | grep "キュアウィンディ"
-    assertEquals 0 $?
+    # echo "${result}" | grep "キュアブライト"
+    # assertEquals 0 $?
+    # echo "${result}" | grep "キュアウィンディ"
+    # assertEquals 0 $?
     echo "${result}" | grep "キュアドリーム"
     assertEquals 0 $?
     echo "${result}" | grep "キュアルージュ"
@@ -198,8 +204,8 @@ test_precures () {
     assertEquals 0 $?
     echo "${result}" | grep "キュアフェリーチェ"
     assertEquals 0 $?
-    echo "${result}" | grep "キュアエコー"
-    assertEquals 0 $?
+    # echo "${result}" | grep "キュアエコー"
+    # assertEquals 0 $?
 }
 
 test_date() {
@@ -338,7 +344,7 @@ test_grep() {
 }
 
 test_humanize() {
-  result=`bundle exec cure precures | bundle exec cure humanize`
+  result=`bundle exec cure precures -m | bundle exec cure humanize`
   echo "${result}" | grep "美墨なぎさ"
   assertEquals 0 $?
   echo "${result}" | grep "雪城ほのか"
@@ -432,7 +438,7 @@ test_humanize() {
 }
 
 test_transform() {
-  result=`bundle exec cure girls | bundle exec cure transform`
+  result=`bundle exec cure girls -m | bundle exec cure transform`
   echo "${result}" | grep "キュアブラック"
   assertEquals 0 $?
   echo "${result}" | grep "キュアホワイト"
@@ -443,10 +449,6 @@ test_transform() {
   assertEquals 0 $?
   echo "${result}" | grep "キュアイーグレット"
   assertEquals 0 $?
-#   echo "${result}" | grep "キュアブライト"
-#   assertEquals 0 $?
-#   echo "${result}" | grep "キュアウィンディ"
-#   assertEquals 0 $?
   echo "${result}" | grep "キュアドリーム"
   assertEquals 0 $?
   echo "${result}" | grep "キュアルージュ"
@@ -541,7 +543,7 @@ test_janken() {
 }
 
 test_tr() {
-  result=`bundle exec cure girls | bundle exec cure tr '[:human_name:]' '[:cast_name:]'`
+  result=`bundle exec cure girls -m | bundle exec cure tr '[:human_name:]' '[:cast_name:]'`
   echo "${result}" | grep "本名陽子"
   assertEquals 0 $?
   echo "${result}" | grep "ゆかな"


### PR DESCRIPTION
* Suppress to show cure bright and cure windy because they are given by duplicated characters.
* Suppress to show the full name of the cure princess(instead, support additional option to show it)
* Support showing version.
* Update zsh-completion file.