### PR TITLE
Update completion file for rubicure v1.0.4

### DIFF
--- a/zsh-completion/_cure
+++ b/zsh-completion/_cure
@@ -42,7 +42,7 @@ precure_girl_names=(
 	'cure_honey'
 	'cure_lemonade'
 	'cure_lovely'
-	'cure_macaroon'
+	'cure_macaron'
 	'cure_magical'
 	'cure_march'
 	'cure_marine'


### PR DESCRIPTION
It is required to update zsh completion file for this change.
https://github.com/sue445/rubicure/pull/149